### PR TITLE
add bnt lock time for frontend

### DIFF
--- a/contracts/DappStakingPool.sol
+++ b/contracts/DappStakingPool.sol
@@ -294,17 +294,18 @@ contract DappStakingPool is OwnableUpgradeable, ITransferPositionCallback {
         UserPoolInfo storage userInfo = userPoolInfo[pid][msg.sender];
         PoolInfo storage pool = poolInfo[pid];
         uint pendingReward = userInfo.pending.add(userInfo.amount.mul(pool.accDappPerShare).div(1e12).sub(userInfo.rewardDebt));
-        require(pendingReward > 0, "no rewards to claim");
-        if (dappRewardsSupply > pendingReward) {
-            dappToken.transfer(msg.sender, pendingReward);
-            dappRewardsSupply = dappRewardsSupply.sub(pendingReward);
-            userInfo.pending = 0;
-            userInfo.rewardDebt = userInfo.amount.mul(pool.accDappPerShare).div(1e12);
-        } else {
-            dappToken.transfer(msg.sender, dappRewardsSupply);
-            dappRewardsSupply = 0;
-            userInfo.pending = pendingReward.sub(dappRewardsSupply);
-            userInfo.rewardDebt = userInfo.amount.mul(pool.accDappPerShare).div(1e12);
+        if(pendingReward > 0) {
+            if (dappRewardsSupply > pendingReward) {
+                dappToken.transfer(msg.sender, pendingReward);
+                dappRewardsSupply = dappRewardsSupply.sub(pendingReward);
+                userInfo.pending = 0;
+                userInfo.rewardDebt = userInfo.amount.mul(pool.accDappPerShare).div(1e12);
+            } else {
+                dappToken.transfer(msg.sender, dappRewardsSupply);
+                dappRewardsSupply = 0;
+                userInfo.pending = pendingReward.sub(dappRewardsSupply);
+                userInfo.rewardDebt = userInfo.amount.mul(pool.accDappPerShare).div(1e12);
+            }
         }
     }
 


### PR DESCRIPTION
In order for the frontend to determine if a user is eligible to claim their locked BNT tokens, a field has been added `bntLocked` which is set to the current time at the time of unlocking plus 24 hours.

When a user goes to `claimUserBnt` they will be unable until the `bntLocked` time is less than or equal to the current time, or in other words the locked time has expired.  Upon claiming, the `bntLocked` time will be reset to 0.

This does not solve or address the edge case where a user could run `claimUserBnt` assuming their was enough BNT in the staking contract itself to cover the IL.  Though this issue can easily be remedied by the user calling the `claimBnt` which will transfer the remaining unlocked tokens after the lock duration expires for that user's portion of the BNT IL.

This feature does address the edge case where the user cannot claim their `claimableBnt` until this expiration has at least been met, regardless of whether the `claimBnt` has been called as discussed in the previous paragraph.

---

Also of note is the potential mutability of the unlock time, which does not appear possible as the `LiquidityProtectionSettings.sol` contract is not under proxy/upgradability. https://github.com/bancorprotocol/contracts-solidity/blob/f4a2ad83f8abd47b43b6922efb07117a18b09116/solidity/contracts/liquidity-protection/LiquidityProtectionSettings.sol#L50